### PR TITLE
Use one db pool per app, not per actix-web worker

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@ extern crate jsonwebtoken as jwt;
 
 use actix_web::{actix::System,server};
 
+use crate::model::db::init;
+
 mod api;
 mod handler;
 mod model;
@@ -28,10 +30,11 @@ fn main() {
     ::std::env::set_var("RUST_BACKTRACE", "1");
     env_logger::init();
     let sys = System::new("wapp");
+    let addr = init();
 
     server::new( move || 
         vec![
-            router::app_state().boxed(),
+            router::app_state(addr.clone()).boxed(),
             router::app().boxed(),
         ])
         .bind("localhost:8000").unwrap()

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,14 +1,13 @@
-use actix_web::{App,fs, http::{header, Method},middleware::{self,cors::Cors}};
+use actix_web::{App,fs, http::{header, Method}, middleware::{self,cors::Cors}, actix::Addr};
 
-use crate::model::db::init;
+use crate::model::db::ConnDsl;
 use crate::share::state::AppState;
 
 use crate::api::{home::{index,path},auth::{signup, signin}};
 use crate::api::article::{article,article_list, article_new};
 use crate::api::user::{user_info, user_delete, user_update};
 
-pub fn app_state() -> App<AppState> {
-     let addr = init();
+pub fn app_state(addr: Addr<ConnDsl>) -> App<AppState> {
      App::with_state(AppState{ db: addr.clone()})
          .middleware(middleware::Logger::default())
          .prefix("/api")


### PR DESCRIPTION
Hello!

There is an issue with db pool & sync actors (ConnDsl): db pool & sync actors pool getting created per actix-web worker thread, not per-app (global). According to actix-web documentation (https://actix.rs/docs/application/):

> Note: http server accepts an application factory rather than an application instance. Http server constructs an application instance for each thread, thus application state must be constructed multiple times.

You can make sure that pools getting created multiple times: just launch app on multi-core machine and count connections in postgres (`select * from pg_stat_activity;`).

This PR fixes this isse by creating one per-app db pool with one per-app sync actors pool and just passing it to app factory.

Same issue here: https://github.com/rustlang-cn/ruster.

Thanks!